### PR TITLE
Change of the contentBase path and improved CSS

### DIFF
--- a/public/visual/styles.css
+++ b/public/visual/styles.css
@@ -61,11 +61,15 @@
 .button{
     position:relative;
     float:left;
-    width: 60px;
-    height: 20px;
-    font-size: 9px;
+    width: 78px;
+    height: 45px;
+    font-size: 16px;
     padding-left: 0px;
     padding-right: 0px;
+    background-color: #4c8caf;
+    color: white;
+    text-decoration: none;
+    padding: 2px;
 }
 .mouseHide{
     visibility: hidden;

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -28,9 +28,11 @@ module.exports = {// Environment mode
     devServer: {
 
         // Serve index.html as the base
-        contentBase: resolveAppPath('public'), 
-    
-        // Enable compression
+
+        //contentBase: resolveAppPath('public'), 
+        // Saida: Is index.html going to be a static file? From web-pack documentation, contentBase primarile serves static content like media and stuff
+        
+       // Enable compression
         compress: true,
     
         // Enable hot reloading


### PR DESCRIPTION
Hey Ayana, I [found](https://stackoverflow.com/questions/62991326/difference-between-publicpath-and-contentbase-in-webpack ) that contentBase is needed in the webpack.json for static files like pics and movies. Is index.html going to be a static file? Since webpack.config had the only reference to public folder that I could find, I thought this would help you with renaming of the index.html. 
I tried moving index.html to the main directory, but JS kept crashing. If contentBase isn't the case, how your JS is dependent on the file path to index.html? 
I also improved a bit the style.css: mainly coloring, sizing, layout. 